### PR TITLE
Implemented FFRNN.

### DIFF
--- a/examples/ff_rnn_mnist.py
+++ b/examples/ff_rnn_mnist.py
@@ -1,0 +1,82 @@
+# %% Imports
+import torch
+
+import sys
+import os
+import argparse
+
+# Get the absolute path of the src directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from fflib.utils.data.mnist import FFMNIST, NegativeGenerator as MNISTNEG
+from fflib.nn.ff_rnn import FFRNN
+from fflib.probes.one_hot import TryAllClasses
+from fflib.utils.ffrnn_suite import FFRNNSuite
+from fflib.utils.ff_logger import logger
+
+# It should skip the argument parser if it finds it runs within an IPython shell.
+parser = argparse.ArgumentParser(exit_on_error=False)
+parser.add_argument("-e", "--epochs", help="Number of epochs", default=60, type=int)
+args = parser.parse_args(args=("" if "get_ipython" in globals() else None))
+
+# Setup the device
+device_type = "cuda" if torch.cuda.is_available() else "cpu"
+logger.info(f"Device type: {device_type}")
+device = torch.device(device_type)
+
+torch.manual_seed(42)
+
+# %% Setup Dataset
+logger.info("Setting up MNIST dataset...")
+mnist = FFMNIST(batch_size=128, validation_split=0.1, negative_generator=MNISTNEG.RANDOM)
+
+# %% Setup the network
+logger.info("Setting up the FFRNN...")
+
+net = FFRNN.from_dimensions(
+    dimensions=[784, 2000, 2000, 10],
+    K_train=10,
+    K_testlow=3,
+    K_testhigh=8,
+    maximize=True,
+    activation_fn=torch.nn.ReLU(),
+    loss_threshold=20,
+    optimizer=torch.optim.Adam,
+    lr=0.02,
+    beta=0.7,
+    device=device,
+)
+# %% Probe
+logger.info("Setting up a probe...")
+probe = TryAllClasses(lambda x, y: net(x, y), output_classes=10)
+
+# %% Create Test Suite
+logger.info("Setting up a TestSuite...")
+suite = FFRNNSuite(net, probe, mnist, device)
+
+# %% Run Train
+logger.info("Running the training procedure...")
+logger.info(f"Parameters: Epochs = {args.epochs}")
+suite.train(args.epochs)
+
+# %% Run Test
+logger.info("Running the testing procedure...")
+suite.test()
+
+# %% Save Model
+logger.info("Saving model...")
+model_path = suite.save("./models/ffrnn_mnist.pt", append_hash=True)
+logger.info(f"Model saved at {model_path}.")
+
+# %% Load Model
+for i in range(len(net.layers)):
+    net.layers[i].reset_parameters()
+
+# Uncomment this and change the filename
+# model_path = "../models/ffrnn_mnist_d9d9f7.pt"
+
+logger.info("Loading the saved model...")
+net = suite.load(model_path)
+
+# %% Retest the model
+suite.test()

--- a/src/fflib/interfaces/iff_recurrent_layer.py
+++ b/src/fflib/interfaces/iff_recurrent_layer.py
@@ -1,0 +1,50 @@
+import torch
+
+from torch.nn import Module
+from abc import ABC, abstractmethod
+from typing import Callable, Tuple, List
+
+
+class IFFRecurrentLayer(ABC, Module):
+    @abstractmethod
+    def reset_parameters(self) -> None:
+        pass
+
+    @abstractmethod
+    def get_dimensions(self) -> int:
+        pass
+
+    @abstractmethod
+    def goodness(
+        self,
+        x_prev: torch.Tensor,
+        x_recc: torch.Tensor,
+        x_next: torch.Tensor,
+        logistic_fn: Callable[[torch.Tensor], torch.Tensor] = lambda x: torch.log(1 + torch.exp(x)),
+        inverse: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Makes inference on the recurrent layer and returns the new output
+        along with the goodness of the given input.
+
+        Args:
+            x_prev (torch.Tensor): Tensor representing the data coming from the prev layer at time t - 1
+            x_recc (torch.Tensor): Tensor representing the data coming from the same layer at time t - 1
+            x_next (torch.Tensor): Tensor representing the data coming from the next layer at time t - 1
+            logistic_fn (_type_, optional): Logistic Function to decide whether the data is positive or negative.
+                Defaults to lambdax:torch.log(1 + torch.exp(x)).
+            inverse (bool, optional): Should we invert the output?. Defaults to False.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: First element being the goodness, second - the output of the layer
+        """
+
+        pass
+
+    @abstractmethod
+    def run_train(
+        self,
+        h_pos: List[torch.Tensor],
+        h_neg: List[torch.Tensor],
+        index: int,
+    ) -> None:
+        pass

--- a/src/fflib/nn/ff_recurrent_layer.py
+++ b/src/fflib/nn/ff_recurrent_layer.py
@@ -1,0 +1,157 @@
+import torch
+import torch.nn as nn
+
+from torch.nn import Module, ReLU
+from torch.optim import Adam
+from fflib.interfaces.iff_recurrent_layer import IFFRecurrentLayer
+from typing import Callable, List, Tuple, cast, Any
+
+
+class FFRecurrentLayer(IFFRecurrentLayer):
+    def __init__(
+        self,
+        fw_features: int,
+        rc_features: int,
+        bw_features: int,
+        loss_threshold: float,
+        lr: float,
+        activation_fn: Module = ReLU(),
+        maximize: bool = True,
+        beta: float = 0.7,
+        optimizer: Callable[..., Any] = Adam,
+        device: Any | None = None,
+    ):
+        super(FFRecurrentLayer, self).__init__()
+        self.loss_threshold = loss_threshold
+        self.activation_fn = activation_fn
+        self.maximize = maximize
+        self.beta = beta
+        self.fw_features = fw_features
+        self.rc_features = rc_features
+        self.bw_features = bw_features
+
+        # fw means Forward Weight
+        # bw means Backward Weight
+        self.fw = nn.Parameter(torch.Tensor(rc_features, fw_features).to(device))
+        self.bw = nn.Parameter(torch.Tensor(rc_features, bw_features).to(device))
+
+        # Bias for each layer
+        self.fb = nn.Parameter(torch.Tensor(rc_features).to(device))
+
+        # Setup the Optimizer
+        self.opt: torch.optim.Optimizer = optimizer(self.parameters(), lr)
+
+        # Initialize parameters
+        self.reset_parameters()
+
+    def get_dimensions(self) -> int:
+        return self.rc_features
+
+    def set_lr(self, lr: float) -> None:
+        """Use this function to update the learning rate while training.
+
+        Args:
+            lr (float): New learning rate.
+        """
+        self.opt.param_groups[0]["lr"] = lr
+
+    def reset_parameters(self) -> None:
+        for weight in [self.fw, self.bw]:
+            nn.init.orthogonal_(weight)
+
+        if self.fb is not None:
+            for bias in [self.fb]:
+                nn.init.uniform_(bias)
+
+    def forward(
+        self,
+        x_prev: torch.Tensor,
+        x_recc: torch.Tensor,
+        x_next: torch.Tensor,
+    ) -> torch.Tensor:
+
+        # Normalization
+        hf: torch.Tensor = x_prev / (x_prev.norm(2, 1, keepdim=True) + 1e-4)
+        hb: torch.Tensor = x_next / (x_next.norm(2, 1, keepdim=True) + 1e-4)
+
+        # Multiply the weights and the features in the forward and backward direction
+        f = torch.mm(hf, self.fw.T)
+        b = torch.mm(hb, self.bw.T)
+
+        # Main equation
+        return cast(
+            torch.Tensor,
+            (
+                self.beta * self.activation_fn(f + b + self.fb.unsqueeze(0))
+                + (1 - self.beta) * x_recc
+            ),
+        )
+
+    def goodness(
+        self,
+        x_prev: torch.Tensor,
+        x_recc: torch.Tensor,
+        x_next: torch.Tensor,
+        logistic_fn: Callable[[torch.Tensor], torch.Tensor] = lambda x: torch.log(1 + torch.exp(x)),
+        inverse: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+
+        x_prev = x_prev.clone().detach()
+        x_recc = x_recc.clone().detach()
+        x_next = x_next.clone().detach()
+
+        y = self.forward(x_prev, x_recc, x_next)
+        z = y.pow(2).mean(1) - self.loss_threshold
+        z = -z if inverse else z
+        g = logistic_fn(z)
+        return g, y
+
+    def run_train(
+        self,
+        h_pos: List[torch.Tensor],
+        h_neg: List[torch.Tensor],
+        index: int,
+    ) -> None:
+
+        g_pos = self.goodness(h_pos[index - 1], h_pos[index], h_pos[index + 1], inverse=True)[0]
+        g_neg = self.goodness(h_neg[index - 1], h_neg[index], h_neg[index + 1], inverse=False)[0]
+
+        loss = torch.cat([g_pos, g_neg]).mean()
+
+        # Zero the gradients
+        self.opt.zero_grad()
+
+        # Compute the backward pass
+        loss.backward()  # type: ignore
+
+        # Perform a step of optimization
+        self.opt.step()
+
+
+class FFRecurrentLayerDummy(IFFRecurrentLayer):
+    def __init__(self, dimensions: int):
+        self.rc_features = dimensions
+
+    def reset_parameters(self) -> None:
+        pass
+
+    def get_dimensions(self) -> int:
+        return self.rc_features
+
+    def goodness(
+        self,
+        x_prev: torch.Tensor,
+        x_recc: torch.Tensor,
+        x_next: torch.Tensor,
+        logistic_fn: Callable[[torch.Tensor], torch.Tensor] = lambda x: torch.log(1 + torch.exp(x)),
+        inverse: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return x_recc, x_recc
+
+    def run_train(
+        self,
+        h_pos: List[torch.Tensor],
+        h_neg: List[torch.Tensor],
+        index: int,
+    ) -> None:
+        pass

--- a/src/fflib/nn/ff_rnn.py
+++ b/src/fflib/nn/ff_rnn.py
@@ -1,0 +1,225 @@
+import torch
+
+from torch.nn import Module
+from fflib.nn.ff_recurrent_layer import FFRecurrentLayer, FFRecurrentLayerDummy
+from fflib.interfaces.iff import IFF
+from fflib.interfaces.iff_recurrent_layer import IFFRecurrentLayer
+from typing import List, Callable, Tuple, cast, Any
+from typing_extensions import Self
+
+
+class FFRNN(IFF, Module):
+    def __init__(
+        self,
+        layers: List[IFFRecurrentLayer],
+        K_train: int,
+        K_testlow: int,
+        K_testhigh: int,
+        device: Any | None = None,
+    ):
+        super().__init__()
+
+        self.K_train = K_train
+        self.K_testlow = K_testlow
+        self.K_testhigh = K_testhigh
+        self.layers = layers
+        self.device = device
+
+        # TODO: LOGS!
+        # self.log: bool = False
+        # self.validation_logs: List[float] = []
+
+    @classmethod
+    def from_dimensions(
+        self,
+        dimensions: List[int],
+        K_train: int,
+        K_testlow: int,
+        K_testhigh: int,
+        maximize: bool,  # Check if all layers have the same maximize
+        activation_fn: Module,
+        loss_threshold: float,
+        optimizer: Callable[..., Any],
+        lr: float,
+        beta: float = 0.7,
+        device: Any | None = None,
+    ) -> Self:
+        """Example wrapper of how one Forward-Forward-based Recurrent Neural Network
+        should be structured. Since the FFRNN uses weights in the backward-flow direction
+        in order to set all of the layers appropriately, the FFRNN wrapper requires
+        a list of all of the dimensions of all of the individual dense layers.
+
+        This wrapper currently only works with fully connected dense layers.
+
+        The list of the dimensions should follow the following structure:
+        ```py
+        dimensions = [input_layer, ...recurrent_layer, output_layer]
+        ```
+
+        Args:
+            dimensions (List[int]): List of the vector dimensions that each layer should have.
+            activation_fn (torch.nn.Module): Activation function.
+            loss_fn (Callable): Loss function.
+            loss_threshold (float): Threshold dividing the positive and negative data.
+            optimizer (Callable): Optimizer type.
+            lr (float): Learning rate.
+            K_train (int): Count of frames in training phase.
+            K_testlow (int): Lowerbound frame taken into account in the testing phase.
+            K_testhigh (int): Upperbound frame taken into account in the testing phase.
+            maximize (bool, optional): Maximize or minimize goodness. Defaults to True.
+            beta (float, optional): Beta factor. Defaults to 0.7.
+            device (_type_, optional): Device. Defaults to None.
+        """
+
+        # Initialize all of the Recurrent Layers
+        layers: List[IFFRecurrentLayer] = [FFRecurrentLayerDummy(dimensions[0])]
+        for i in range(1, len(dimensions) - 1):
+            layers.append(
+                FFRecurrentLayer(
+                    dimensions[i - 1],
+                    dimensions[i],
+                    dimensions[i + 1],
+                    loss_threshold,
+                    lr,
+                    activation_fn,
+                    maximize,
+                    beta,
+                    optimizer,
+                    device,
+                )
+            )
+
+        layers.append(FFRecurrentLayerDummy(dimensions[-1]))
+
+        return self(
+            layers,
+            K_train,
+            K_testlow,
+            K_testhigh,
+            device,
+        )
+
+    def get_layer_count(self) -> int:
+        return len(self.layers) - 2
+
+    def create_init_activations(self) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        hp_pos = [
+            torch.Tensor(
+                1,
+                (self.layers[i].get_dimensions()),
+            ).to(self.device)
+            for i in range(len(self.layers))
+        ]
+
+        hp_neg = [
+            torch.Tensor(
+                1,
+                (self.layers[i].get_dimensions()),
+            ).to(self.device)
+            for i in range(len(self.layers))
+        ]
+
+        for h in hp_pos:
+            torch.nn.init.uniform_(h)
+        for h in hp_neg:
+            torch.nn.init.uniform_(h)
+
+        return hp_pos, hp_neg
+
+    def _goodness_layer(
+        self,
+        x: List[torch.Tensor],
+        index: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """It returns the goodness along with the computed internal hidden states as the second element.
+        The goodness tensor should have dimensions (BATCH_SIZE,).
+        The activations tensor should have dimensions (BATCH_SIZE, LAYER_DIMENSION).
+
+        Args:
+            x (List[torch.Tensor]): Activations of all the layers at the present time
+            index (int): Index of the layer from which we compute the goodness
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: [goodness, activations]
+        """
+        return self.layers[index].goodness(x[index - 1], x[index], x[index + 1])
+
+    def _forward_layer(self, x: List[torch.Tensor], index: int) -> torch.Tensor:
+        return cast(torch.Tensor, self.layers[index].forward(x[index - 1], x[index], x[index + 1]))
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        # Setup the activations and the image input
+        activations = [
+            torch.Tensor(1, self.layers[i].get_dimensions()).to(self.device)
+            for i in range(len(self.layers))
+        ]
+
+        for h in activations:
+            torch.nn.init.uniform_(h)
+
+        activations[0] = x.to(self.device)
+        activations[-1] = y.to(self.device)
+
+        # Push one forward pass
+        for i in range(1, len(activations) - 1):
+            activations[i] = self._goodness_layer(activations, i)[1].detach()
+
+        goodness: List[torch.Tensor] = []  # (batch_size,)**layers
+        # Run it for K iterations
+        for frame in range(self.K_testhigh):
+            new_activations = [h.clone() for h in activations]
+            for i in range(1, len(self.layers) - 1):
+                g, y = self._goodness_layer(activations, i)
+                new_activations[i] = y.detach()
+
+                if frame > self.K_testlow:
+                    goodness.append(g)
+
+            activations = new_activations
+
+        # (batch_size,)**layers -> (layers, batch_size)
+        result = torch.stack(goodness)
+        # (layers, batch_size) -> (batch_size, )
+        result = result.mean(dim=0)
+        return result
+
+    def run_train(
+        self,
+        x_pos: torch.Tensor,
+        y_pos: torch.Tensor,
+        x_neg: torch.Tensor,
+        y_neg: torch.Tensor,
+    ) -> None:
+
+        # Fetch and prepare a new batch
+        h_pos, h_neg = self.create_init_activations()
+
+        # Set the input to the pos and neg data
+        h_pos[0] = x_pos
+        h_neg[0] = x_neg
+        h_pos[-1] = y_pos
+        h_neg[-1] = y_neg
+
+        # Push one forward pass
+        for i in range(1, len(self.layers) - 1):
+            h_pos[i] = self._forward_layer(h_pos, i).detach()
+            h_neg[i] = self._forward_layer(h_neg, i).detach()
+
+        # Start training the network
+        for _ in range(self.K_train):
+            h_new_pos = [a.clone() for a in h_pos]
+            h_new_neg = [a.clone() for a in h_neg]
+            for i in range(1, len(self.layers) - 1):
+                self.layers[i].run_train(h_pos, h_neg, i)
+                h_new_pos[i] = self._forward_layer(h_pos, i).detach()
+                h_new_neg[i] = self._forward_layer(h_neg, i).detach()
+            h_pos = h_new_pos
+            h_neg = h_new_neg
+
+    def run_train_combined(
+        self,
+        x_pos: torch.Tensor,
+        x_neg: torch.Tensor,
+    ) -> None:
+
+        raise NotImplementedError("Use run_train function with separate X and Y data inputs.")

--- a/src/fflib/utils/data/dataprocessor.py
+++ b/src/fflib/utils/data/dataprocessor.py
@@ -56,5 +56,10 @@ class FFDataProcessor(ABC):
         pass
 
     @abstractmethod
-    def generate_negative(self, x: torch.Tensor, y: torch.Tensor, net: IFF) -> torch.Tensor:
+    def generate_negative(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        net: IFF,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         pass

--- a/src/fflib/utils/data/mnist.py
+++ b/src/fflib/utils/data/mnist.py
@@ -9,7 +9,7 @@ from fflib.utils.data import FFDataProcessor
 from fflib.interfaces.iff import IFF
 
 from enum import Enum
-from typing import Dict, Callable, Any
+from typing import Tuple, Dict, Callable, Any
 
 
 class NegativeGenerator(Enum):
@@ -95,19 +95,22 @@ class FFMNIST(FFDataProcessor):
     def combine_to_input(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         return torch.cat((x, y), 1)
 
-    def generate_negative(self, x: torch.Tensor, y: torch.Tensor, net: IFF) -> torch.Tensor:
+    def generate_negative(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        net: IFF,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
 
         if self.negative_generator == NegativeGenerator.HIGHEST_INCORRECT:
             raise NotImplementedError()
 
         if self.negative_generator == NegativeGenerator.INVERSE:
             y_hot = 1 - one_hot(y, num_classes=10).float()
-            result = torch.cat((x, y_hot), 1)
-            return result
+            return x, y_hot
 
         rnd = torch.rand((x.shape[0], 10), device=x.device)
         rnd[torch.arange(x.shape[0]), y] = 0
         y_new = rnd.argmax(1)
         y_hot = one_hot(y_new, num_classes=10).float()
-        result = torch.cat((x, y_hot), 1)
-        return result
+        return x, y_hot

--- a/src/fflib/utils/ffc_suite.py
+++ b/src/fflib/utils/ffc_suite.py
@@ -7,7 +7,7 @@ from fflib.nn.ffc import FFC
 from fflib.interfaces import IFFProbe
 from fflib.utils.ff_logger import logger
 
-from typing import Dict, Any, cast
+from typing import Any, cast
 
 
 class FFCSuite(IFFSuite):
@@ -29,7 +29,8 @@ class FFCSuite(IFFSuite):
         if self.train_classifier == False:
             y_enc = self.dataloader.encode_output(y)
             x_pos = self.dataloader.combine_to_input(x, y_enc)
-            x_neg = self.dataloader.generate_negative(x, y, self.net)
+            x_neg, y_neg = self.dataloader.generate_negative(x, y, self.net)
+            x_neg = self.dataloader.combine_to_input(x_neg, y_neg)
 
             self.net.run_train_combined(x_pos, x_neg)
         else:

--- a/src/fflib/utils/ffrnn_suite.py
+++ b/src/fflib/utils/ffrnn_suite.py
@@ -2,29 +2,28 @@ import torch
 
 from fflib.utils.data.dataprocessor import FFDataProcessor
 from fflib.utils.iff_suite import IFFSuite
-from fflib.nn.ff_net import FFNet
+from fflib.nn.ff_rnn import FFRNN
 from fflib.interfaces import IFFProbe
 
 from typing import Any
 
 
-class FFSuite(IFFSuite):
+class FFRNNSuite(IFFSuite):
     def __init__(
         self,
-        ff_net: FFNet,
+        ffc: FFRNN,
         probe: IFFProbe,
         dataloader: FFDataProcessor,
         device: Any | None = None,
     ):
-        super().__init__(ff_net, probe, dataloader, device)
+        super().__init__(ffc, probe, dataloader, device)
+        self.time_to_train: float = 0
 
     def _train(self, x: torch.Tensor, y: torch.Tensor) -> None:
         y_enc = self.dataloader.encode_output(y)
-        x_pos = self.dataloader.combine_to_input(x, y_enc)
         x_neg, y_neg = self.dataloader.generate_negative(x, y, self.net)
-        x_neg = self.dataloader.combine_to_input(x_neg, y_neg)
 
-        self.net.run_train_combined(x_pos, x_neg)
+        self.net.run_train(x, y_enc, x_neg, y_neg)
 
     def _test(self, x: torch.Tensor) -> torch.Tensor:
         return self.probe.predict(x)

--- a/src/fflib/utils/iff_suite.py
+++ b/src/fflib/utils/iff_suite.py
@@ -101,7 +101,7 @@ class IFFSuite:
         # Validation phase
         if validate and loaders["val"] is not None:
             val_accuracy = self.run_test_epoch(loaders["val"])
-            logger.info(f"Val Accuracy: {val_accuracy:.4f}")
+            logger.info(f"Epoch: {self.current_epoch + 1} - Val Accuracy: {val_accuracy:.4f}")
             self.epoch_data.append(
                 {
                     "epoch": self.current_epoch + 1,
@@ -151,7 +151,7 @@ class IFFSuite:
 
     def save(
         self, filepath: str, extend_dict: Dict[str, Any] = {}, append_hash: bool = False
-    ) -> None:
+    ) -> str:
         data = {
             "hidden_layers": self.net.get_layer_count(),
             "current_epoch": self.current_epoch,
@@ -175,6 +175,7 @@ class IFFSuite:
             filepath = self.append_to_filename(filepath, suffix)
 
         torch.save(data, filepath)
+        return filepath
 
     def load(self, filepath: str) -> Any:
         """Load a pretrained FF model.


### PR DESCRIPTION
 - Implemented the FFRNN type of FF network.
 - Changed the `generate_negative` function interface to give out both `x` and `y` data.
 - `suite.save()` now returns the filepath of the saved model.
 - The FFRNN example supports arguments only from CLI. In IPython Shell it should work the same.