### PR TITLE
Create hooks dictionary on network load.

### DIFF
--- a/examples/bp_mnist.py
+++ b/examples/bp_mnist.py
@@ -88,7 +88,7 @@ torch.manual_seed(42)
 
 # %% Setup Dataset
 logger.info("Setting up MNIST dataset...")
-mnist = FFMNIST(batch_size=256, validation_split=0.1)
+mnist = FFMNIST(batch_size=256, validation_split=0.1, use=args.use)
 
 # %% Setup Dense Backpropagation Network
 net = BPDenseNet(0.001)

--- a/src/fflib/utils/iff_suite.py
+++ b/src/fflib/utils/iff_suite.py
@@ -11,7 +11,7 @@ from fflib.utils.ff_logger import logger
 from fflib.utils.data.dataprocessor import FFDataProcessor
 
 from abc import abstractmethod
-from typing import Callable, List, Dict, Tuple, Any
+from typing import Callable, List, Dict, Tuple, cast, Any
 
 
 class IFFSuite:
@@ -168,7 +168,8 @@ class IFFSuite:
             "time_to_train": self.time_to_train,
         }
 
-        delattr(self.net, "hooks")
+        if hasattr(self.net, "hooks"):
+            delattr(self.net, "hooks")
 
         # Check key duplication
         for key in data.keys():
@@ -201,4 +202,5 @@ class IFFSuite:
             setattr(self, key, value)
 
         self.net = data["net"].to(self.device)
+        cast(IFF, self.net)._create_hooks_dict()
         return self.net


### PR DESCRIPTION
When importing a model, immediately create the hooks dictionary since it will be deleted automatically in any case if the model is exported. Also, properly utilize the "use" argument in the BP example.